### PR TITLE
Update to rollup v0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "co": "^4.6.0",
-    "rollup": "^0.25.7"
+    "rollup": "^0.26"
   },
   "devDependencies": {
     "ava": "^0.15.2",


### PR DESCRIPTION
This addresses an upstream issue discussed [here](https://github.com/rollup/rollup/issues/642#issuecomment-217019377) that I was experiencing with the following JavaScript:

``` js
import { select } from 'd3-selection'
window.root = select('body')
```
